### PR TITLE
Make footer mobile responsive

### DIFF
--- a/waterloop-site/src/components/SustainableTech/Footer/STEFooter.tsx
+++ b/waterloop-site/src/components/SustainableTech/Footer/STEFooter.tsx
@@ -168,11 +168,6 @@ const SocialsWrapper = styled.div`
     justify-content: space-evenly;
     width: 100vw;
   }
-  @media screen and (max-width: 425px) {
-    align-self: center;
-    justify-content: space-evenly;
-    width: 100vw;
-  }
 `;
 
 const SocialBubble = styled.a`
@@ -185,9 +180,6 @@ const SocialBubble = styled.a`
   border-radius: 50%;
   margin-left: 25px;
   @media screen and (max-width: 1024px) {
-    margin-left: 0px;
-  }
-  @media screen and (max-width: 425px) {
     margin-left: 0px;
   }
 `;

--- a/waterloop-site/src/components/SustainableTech/Footer/STEFooter.tsx
+++ b/waterloop-site/src/components/SustainableTech/Footer/STEFooter.tsx
@@ -22,10 +22,16 @@ const FooterBackground = styled.div`
   padding: 2.5rem 6rem 7.5rem;
   transition: all 0.3s;
   border: none !important;
+  @media screen and (max-width: 1024px) {
+    min-height: 15vh;
+  }
   @media screen and (max-width: 425px) {
     padding: 1rem;
-    min-height: 70vh;
+    min-height: 30vh;
     overflow: hidden;
+  }
+  @media screen and (max-width: 375px) {
+    min-height: 35vh;
   }
 `;
 
@@ -33,6 +39,10 @@ const LogoAndContactWrapper = styled.div`
   display: flex;
   flex-direction: row;
   justify-content: start;
+  @media screen and (max-width: 425px) {
+    padding-top: 3vh;
+    padding-bottom: 2vh;
+  }
 `;
 
 const Logo = styled.img.attrs({
@@ -42,6 +52,10 @@ const Logo = styled.img.attrs({
   width: 260px;
   height: 150px;
   margin-bottom: -15px; // required to make up for slight gap in the svg
+  @media screen and (max-width: 425px) {
+    width: 132px;
+    height: 71px;
+  }
 `;
 
 const ContactDiv = styled.div`
@@ -97,7 +111,7 @@ const PageTagsAndSocialsWrapper = styled.div`
   display: flex;
   flex-direction: row;
   justify-content: space-between;
-  @media screen and (max-width: 990px) {
+  @media screen and (max-width: 1024px) {
     flex-direction: column;
   }
 `;
@@ -105,6 +119,17 @@ const PageTagsAndSocialsWrapper = styled.div`
 const PageTagsWrapper = styled.div`
   display: flex;
   flex-direction: row;
+  @media screen and (max-width: 1024px) {
+    align-self: center
+    width: 100vw;
+    justify-content: space-evenly;
+  }
+  @media screen and (max-width: 425px) {
+    align-self: center;
+    width: 100vw;
+    justify-content: space-evenly;
+    padding-bottom: 1vh;
+  }
 `;
 
 const Tag = styled.p`
@@ -112,6 +137,13 @@ const Tag = styled.p`
   color: ${fill};
   margin-right: 50px;
   cursor: pointer;
+  @media screen and (max-width: 1024px) {
+    margin-right: 0px;
+  }
+  @media screen and (max-width: 425px) {
+    font-size: 12px;
+    margin-right: 0px;
+  }
 `;
 
 const Tags = [
@@ -131,6 +163,16 @@ const Socials = [
 
 const SocialsWrapper = styled.div`
   display: flex;
+  @media screen and (max-width: 1024px) {
+    align-self: center;
+    justify-content: space-evenly;
+    width: 100vw;
+  }
+  @media screen and (max-width: 425px) {
+    align-self: center;
+    justify-content: space-evenly;
+    width: 100vw;
+  }
 `;
 
 const SocialBubble = styled.a`
@@ -142,6 +184,12 @@ const SocialBubble = styled.a`
   background-color: #fff;
   border-radius: 50%;
   margin-left: 25px;
+  @media screen and (max-width: 1024px) {
+    margin-left: 0px;
+  }
+  @media screen and (max-width: 425px) {
+    margin-left: 0px;
+  }
 `;
 
 interface SocialProps {

--- a/waterloop-site/src/components/SustainableTech/Footer/STEFooter.tsx
+++ b/waterloop-site/src/components/SustainableTech/Footer/STEFooter.tsx
@@ -24,6 +24,7 @@ const FooterBackground = styled.div`
   border: none !important;
   @media screen and (max-width: 1024px) {
     min-height: 15vh;
+    align-items: center;
   }
   @media screen and (max-width: 425px) {
     padding: 1rem;
@@ -40,8 +41,7 @@ const LogoAndContactWrapper = styled.div`
   flex-direction: row;
   justify-content: start;
   @media screen and (max-width: 425px) {
-    padding-top: 3vh;
-    padding-bottom: 2vh;
+    margin: 2vh 0;
   }
 `;
 
@@ -51,10 +51,12 @@ const Logo = styled.img.attrs({
 })`
   width: 260px;
   height: 150px;
+  margin-right: 20px;
   margin-bottom: -15px; // required to make up for slight gap in the svg
   @media screen and (max-width: 425px) {
     width: 132px;
     height: 71px;
+    margin-top: 1vh; //this is to manually center the logo vertically
   }
 `;
 
@@ -125,9 +127,6 @@ const PageTagsWrapper = styled.div`
     justify-content: space-evenly;
   }
   @media screen and (max-width: 425px) {
-    align-self: center;
-    width: 100vw;
-    justify-content: space-evenly;
     padding-bottom: 1vh;
   }
 `;
@@ -143,7 +142,6 @@ const Tag = styled.p`
   }
   @media screen and (max-width: 425px) {
     font-size: 12px;
-    margin-right: 0px;
   }
 `;
 

--- a/waterloop-site/src/components/SustainableTech/Footer/STEFooter.tsx
+++ b/waterloop-site/src/components/SustainableTech/Footer/STEFooter.tsx
@@ -139,6 +139,7 @@ const Tag = styled.p`
   cursor: pointer;
   @media screen and (max-width: 1024px) {
     margin-right: 0px;
+    justify-content: center;
   }
   @media screen and (max-width: 425px) {
     font-size: 12px;
@@ -165,8 +166,12 @@ const SocialsWrapper = styled.div`
   display: flex;
   @media screen and (max-width: 1024px) {
     align-self: center;
-    justify-content: space-evenly;
-    width: 100vw;
+    justify-content: space-between;
+    width: 35vw;
+  }
+  @media screen and (max-width: 425px) {
+    transform: scale(0.8);
+    width: 70vw;
   }
 `;
 


### PR DESCRIPTION
**Changes**

- Made footer responsive for mobile
- Made footer responsive for tablet
- I added a second commit to get rid of the redundant css

**How Has This Been Tested?**

- [x] Verified that the design matches the figma
- [x] Tested responsiveness in mobile and tablet mode

See screenshots below for what it looks like on mobile and tablet.
Ipad Air:
<img width="548" alt="Screen Shot 2022-03-12 at 8 59 26 PM" src="https://user-images.githubusercontent.com/84100023/158041947-6eaa8156-3116-4ccf-9424-37d233bf969f.png">
Ipad Pro:
<img width="614" alt="Screen Shot 2022-03-12 at 8 59 11 PM" src="https://user-images.githubusercontent.com/84100023/158041959-db75bd68-2c14-4094-8178-5db6f601d076.png">
Smaller Iphone:
<img width="491" alt="Screen Shot 2022-03-12 at 8 43 43 PM" src="https://user-images.githubusercontent.com/84100023/158041978-ebc669f4-becb-481a-9dba-a54e94d12795.png">
Bigger Iphone
<img width="496" alt="Screen Shot 2022-03-12 at 8 43 52 PM" src="https://user-images.githubusercontent.com/84100023/158041982-36fab248-b6d8-4acb-964a-0fa3dc41f37d.png">

