### PR TITLE
[CU-233uw5h] Fix desktop view of Nav Bar and Hero

### DIFF
--- a/waterloop-site/src/components/SustainableTech/Hero/Hero.tsx
+++ b/waterloop-site/src/components/SustainableTech/Hero/Hero.tsx
@@ -11,16 +11,13 @@ const LandingContainer = styled.div`
   background-position: center;
   background-color: #e5f6fa;
   height: 100vh;
+  z-index: -6;
 `;
 
 const MainContent = styled.div`
-  position: absolute;
-  top: 38%;
-  left: 50%;
-  transform: translate(-50%, -50%);
   display: flex;
   flex-direction: column;
-  justify-content: center;
+  justify-content: flex-start;
   align-items: center;
   height: 100%;
 `;
@@ -28,25 +25,43 @@ const MainContent = styled.div`
 const GreenTech = styled.img`
   height: 300px;
   width: auto;
+  padding-top: 8%;
 
   @media (max-width: 1200px) {
     height: 250px;
+    padding-top: 120px;
+  }
+
+  @media (max-height: 800px) {
+    height: 300px;
+    padding-top: 120px;
   }
 
   @media (max-height: 670px) {
     height: 200px;
+    padding-top: 80px;
   }
 
   @media (max-height: 580px) {
     height: 170px;
   }
 
-  @media (max-width: 430px) {
+  @media (max-width: 550px) {
     height: 190px;
   }
 
-  @media (max-width: 300px) {
+  @media (max-width: 450px) {
+    padding-top: 150px;
+    height: 190px;
+  }
+
+  @media (max-width: 330px) {
     height: 150px;
+  }
+
+  @media (max-width: 250px) {
+    padding-top: 120px;
+    height: 130px;
   }
 `;
 
@@ -58,9 +73,9 @@ const ButtonContainer = styled.button`
   font-family: 'IBM Plex Sans';
   font-size: 19px;
   font-weight: 500;
-  padding: 15px 15%;
+  padding: 16px 5%;
   border: #203d7a;
-  margin: 10% 0;
+  margin: 3% 0;
   font-weight: 600;
 
   &:hover {
@@ -69,10 +84,24 @@ const ButtonContainer = styled.button`
     background-color: white;
   }
 
+  @media (max-width: 1300px) {
+    padding: 10px 9%;
+  }
+
+  @media (max-height: 670px) {
+    padding: 10px 40px;
+  }
+
   @media (max-width: 650px) {
     font-size: 17px;
     padding: 10px 15%;
+    margin-top: 50px;
   }
+
+  @media (max-width: 380px) {
+    margin-top: 60px;
+  }
+  
 `;
 
 const Hero: React.FC = () => (

--- a/waterloop-site/src/components/SustainableTech/NavBar/NavBar.tsx
+++ b/waterloop-site/src/components/SustainableTech/NavBar/NavBar.tsx
@@ -20,14 +20,13 @@ const NavbarContainer = styled.div`
 `;
 
 const IconBlack = styled.img`
-  padding-top: 4px;
   width: 55px;
   height: 35px;
   -webkit-transition: 0.2s ease-in-out;
   transition: 0.2s ease-in-out;
   position: absolute;
   left: 40px;
-  top: 10px;
+  top: 13px;
 
   @media screen and (max-width: 900px) {
     width: 50px;
@@ -35,8 +34,10 @@ const IconBlack = styled.img`
   }
 
   @media screen and (max-width: 600px) {
-    width: 43px;
-    height: 25px;
+    width: 40px;
+    height: 27px;
+    left: 20px;
+    top: 15px;
   }
 `;
 
@@ -113,7 +114,13 @@ const ButtonContainer = styled.button`
   }
 
   @media screen and (max-width: 720px) {
-    font-size: 10px;
+    font-size: 13px;
+  }
+
+  @media screen and (max-width: 600px) {
+    right: 11px;
+    top: 16px;
+    font-size: 8px;
   }
 `;
 

--- a/waterloop-site/src/components/SustainableTech/NavBar/NavBar.tsx
+++ b/waterloop-site/src/components/SustainableTech/NavBar/NavBar.tsx
@@ -9,7 +9,7 @@ const NavbarContainer = styled.div`
   display: flex;
   flex-direction: row;
   align-items: center;
-  justify-content: space-between;
+  justify-content: center;
   width: 100%;
   height: 64px;
   background-color: #e5f6fa;
@@ -25,6 +25,9 @@ const IconBlack = styled.img`
   height: 35px;
   -webkit-transition: 0.2s ease-in-out;
   transition: 0.2s ease-in-out;
+  position: absolute;
+  left: 40px;
+  top: 10px;
 
   @media screen and (max-width: 900px) {
     width: 50px;
@@ -35,10 +38,6 @@ const IconBlack = styled.img`
     width: 43px;
     height: 25px;
   }
-`;
-
-const LogoContainer = styled.div`
-  padding-left: 4vw;
 `;
 
 const ListContainer = styled.div`
@@ -98,8 +97,10 @@ const ButtonContainer = styled.button`
   font-size: 17px;
   font-weight: 500;
   padding: 10px 3%;
-  margin-right: 4vw;
   border: #203d7a;
+  position: absolute;
+  right: 40px;
+  top: 10px;
 
   &:hover {
     background-color: white;
@@ -118,11 +119,9 @@ const ButtonContainer = styled.button`
 
 const NavBar: React.FC = () => (
   <NavbarContainer>
-    <LogoContainer>
       <Link to="/">
         <IconBlack src={IconBlackImg} />
       </Link>
-    </LogoContainer>
     <ListContainer>
       <ScrollLink onClick={(): void => scrollTo('home-scroll')}>
         HOME

--- a/waterloop-site/src/components/SustainableTech/NavBar/SideBar.tsx
+++ b/waterloop-site/src/components/SustainableTech/NavBar/SideBar.tsx
@@ -75,7 +75,7 @@ const StyledToggle = styled.button`
   width: 52px;
   height: 40px;
   margin-top: 15px;
-  margin-right: 20px;
+  padding-right: 20px;
   margin-bottom: 15px;
   background: transparent;
   border: none;


### PR DESCRIPTION
## Changes
- Centered the Nav Links
- Fixed the overflowing Green Tech logo that appeared when you opened the sidebar 
- Fixed the issue where the Green Tech logo gets cut off in different viewports 

 ### Note:
- Since the footer responsiveness PR hasnt been merged yet, when you run this branch there will be overflow from it. Delete the footer in inspect element to see that once the footer is fixed the nav bar and hero work as intended. 

## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?
- [x] viewed the changes in different viewports with inspect element

# Images:
<img width="442" alt="Screen Shot 2022-03-13 at 3 07 47 PM" src="https://user-images.githubusercontent.com/62915953/158103930-34b8ddd3-ce38-4661-bbda-59b43a92a195.png">
<img width="1150" alt="Screen Shot 2022-03-13 at 3 25 48 PM" src="https://user-images.githubusercontent.com/62915953/158103934-07f0c15a-e8ee-4299-a986-726a49d13ea0.png">

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation/READ-ME/UMLS
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works